### PR TITLE
Create graphs

### DIFF
--- a/plotting.py
+++ b/plotting.py
@@ -1,0 +1,39 @@
+import matplotlib.pyplot as plt
+
+# Generates distinct colours given a number. Returns black if the index is too high
+def get_color(index):
+    colors = [
+        'red', 'blue', 'green', 'purple', 'cyan', 'lime', 'indigo', 'crimson',
+        'dodgerblue', 'deepskyblue', 'coral', 'saddlebrown', 'orange', 'olive'
+    ]
+    if (index < len(colors)):
+        return colors[index]
+    return 'black'
+
+
+def plot_author_roc_auc_curve(author, fpr, tpr, roc_auc, color='darkorange', directory="classResults", session_name=""):
+    plt.figure()
+    lw = 2
+    plt.plot(
+        fpr, tpr, color=color, lw=lw,
+        label='ROC curve (area = %0.2f)' % roc_auc
+    )
+    plt.plot([0, 1], [0, 1], color='navy', lw=lw, linestyle='--')
+    plt.xlim([0.0, 1.0])
+    plt.ylim([0.0, 1.05])
+    plt.xlabel('False Positive Rate')
+    plt.ylabel('True Positive Rate')
+    plt.title('ROC Curve for {}'.format(author))
+    plt.legend(loc="lower right")
+
+    plot_filepath = "{}/{}_{}_ROC.png".format(directory, session_name, author)
+    plt.savefig(plot_filepath)
+
+
+def plot_roc_auc_curves(results, directory="classResults", session_name=""):
+    # Plot individual author ROC curves
+    for i, (author, metrics) in enumerate(results.items()):
+        plot_author_roc_auc_curve(
+            author, metrics["fpr"], metrics["tpr"], metrics[author]["AUC"], get_color(i),
+            directory=directory, session_name=session_name
+        )

--- a/plotting.py
+++ b/plotting.py
@@ -1,4 +1,7 @@
+import numpy as np
 import matplotlib.pyplot as plt
+from scipy import interp
+from sklearn.metrics import auc
 
 # Generates distinct colours given a number. Returns black if the index is too high
 def get_color(index):
@@ -9,6 +12,34 @@ def get_color(index):
     if (index < len(colors)):
         return colors[index]
     return 'black'
+
+def get_avg_roc_auc(results):
+    # aggregate all fpr for all authors
+    all_fpr = np.unique(np.concatenate([result["fpr"] for _, result in results.items()]))
+
+    # Interpolate all ROC curves that these points
+    mean_tpr = np.zeros_like(all_fpr)
+    weighted_mean_tpr = np.zeros_like(all_fpr)
+
+    for author, metrics in results.items():
+        mean_tpr += interp(all_fpr, metrics["fpr"], metrics["tpr"])
+        weighted_mean_tpr += interp(all_fpr, metrics["fpr"], metrics["tpr"]) * metrics[author]["%"]
+
+    # Average out results
+    mean_tpr /= len(results)
+    averages = {
+        "unweighted": {
+            "fpr": all_fpr,
+            "tpr": mean_tpr,
+            "AUC": auc(all_fpr, mean_tpr),
+        },
+        "weighted": {
+            "fpr": all_fpr,
+            "tpr": weighted_mean_tpr,
+            "AUC": auc(all_fpr, weighted_mean_tpr),
+        },
+    }
+    return averages
 
 
 def plot_author_roc_auc_curve(author, fpr, tpr, roc_auc, color='darkorange', directory="classResults", session_name=""):
@@ -38,8 +69,23 @@ def plot_roc_auc_curves(results, directory="classResults", session_name=""):
             directory=directory, session_name=session_name
         )
 
-    # Plot all ROC curves
     lw = 2
+    plt.figure(figsize=(10, 10))
+
+    roc_averages = get_avg_roc_auc(results)
+    # Plot macro average ROC
+    plt.plot(
+        roc_averages["unweighted"]["fpr"], roc_averages["unweighted"]["tpr"], color="deeppink", lw=lw,
+        label="macro average ROC curve (area = {0:0.1f})".format(roc_averages["unweighted"]["AUC"]),
+        linestyle=":",
+    )
+    # Plot weighted average ROC
+    plt.plot(
+        roc_averages["weighted"]["fpr"], roc_averages["weighted"]["tpr"], color="teal", lw=lw,
+        label="weighted average ROC curve (area = {0:0.1f})".format(roc_averages["weighted"]["AUC"]),
+        linestyle=":",
+    )
+    # Plot all ROC curves
     for i, (author, metrics) in enumerate(results.items()):
         plt.plot(
             metrics["fpr"], metrics["tpr"], color=get_color(i), lw=lw,

--- a/plotting.py
+++ b/plotting.py
@@ -37,3 +37,22 @@ def plot_roc_auc_curves(results, directory="classResults", session_name=""):
             author, metrics["fpr"], metrics["tpr"], metrics[author]["AUC"], get_color(i),
             directory=directory, session_name=session_name
         )
+
+    # Plot all ROC curves
+    lw = 2
+    for i, (author, metrics) in enumerate(results.items()):
+        plt.plot(
+            metrics["fpr"], metrics["tpr"], color=get_color(i), lw=lw,
+            label="ROC curve for {0:s} (area = {1:0.1f})".format(author, metrics[author]["AUC"]),
+        )
+    plt.plot([0, 1], [0, 1], color='navy', lw=lw, linestyle='--')
+    plt.xlim([0.0, 1.0])
+    plt.ylim([0.0, 1.05])
+    plt.xlabel('False Positive Rate')
+    plt.ylabel('True Positive Rate')
+    plt.title('All ROC Curves for {}'.format(session_name))
+    plt.legend(loc="lower right")
+
+    # Save plot
+    plot_filepath = "{}/{}_All_ROC.png".format(directory, session_name)
+    plt.savefig(plot_filepath)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ gitdb2==2.0.5
 GitPython==2.1.11
 javalang==0.12.0
 lizard==1.15.7
+matplotlib==3.0.3
 numpy==1.16.1
 PyDriller==1.7
 pytz==2018.9


### PR DESCRIPTION
Created plotting functions for plotting ROC AUC curves for all authors, macro average, and weighted average.

The plots are created when the classification report is generated, and are saved as images with the name of `sessionName_authorName_ROC.png`. The plot with all ROC curves and average ROC curves overlayed is saved under `sessionName_All_ROC.png`

There doesn't appear to be a significant difference between weighted and unweighted averages.

Here are some plots from the caffe repo:
![caffetest_Eric Tzeng_ROC](https://user-images.githubusercontent.com/7572595/54483678-db362e00-482d-11e9-96b5-977de6ff7130.png)
![caffetest_All_ROC](https://user-images.githubusercontent.com/7572595/54483679-e2f5d280-482d-11e9-8a1a-7d38edb3d4a3.png)
