### PR TITLE
Make all experiments script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /repos/
 *.token
 ghmining*.json
+allExperiments.cid

--- a/coderID.py
+++ b/coderID.py
@@ -822,7 +822,6 @@ class MyPrompt(Cmd):
                         else:
                             self.onecmd(line)
                     except Exception as e:
-                        #import pdb; pdb.set_trace()
                         print(e)
                         print("invalid command: " + line)
         else:

--- a/coderID.py
+++ b/coderID.py
@@ -597,7 +597,7 @@ class MyPrompt(Cmd):
         report = classification_report(pred, tar, output_dict=True)
          
 
-        with open(self.resultLocation+expName+"_multi_report.csv", 'w+') as reportFile:
+        with open(self.resultLocation + expName + "_single_model_multi_report.csv", 'w+') as reportFile:
             w = csv.writer(reportFile)
             oneReport = list(report.items())[0]     
             oneSample = oneReport[1]
@@ -821,8 +821,10 @@ class MyPrompt(Cmd):
                             continue
                         else:
                             self.onecmd(line)
-                    except:
-                        print("invalid command: "+line)
+                    except Exception as e:
+                        #import pdb; pdb.set_trace()
+                        print(e)
+                        print("invalid command: " + line)
         else:
             print("please provide a coderID script file.")
 

--- a/generate_metrics_bar_graph.py
+++ b/generate_metrics_bar_graph.py
@@ -16,7 +16,7 @@ def get_report_precision_recall(filename):
 
 # Returns list of all overall precision and recall from sessions listed in the file
 def get_session_metrics(filepath):
-    session_df = pd.read_csv("bar_graph_sessions.csv")
+    session_df = pd.read_csv(filepath)
 
     sessions = list(session_df["session"])
     report_paths = list(session_df["report_filepath"])

--- a/runAllExperiments.sh
+++ b/runAllExperiments.sh
@@ -4,7 +4,7 @@ SESSION="experimentSession"
 MIN_COMMITS=50
 
 if [ "$#" -gt 3 ] || [ "$#" -lt 1 ]; then
-    echo "Invalid number of  paramters. Usage: ./$0 repopath [ sessionName ] [ minCommits ]"
+    echo "Invalid number of paramters. Usage: ./$0 repopath [ sessionName ] [ minCommits ]"
     exit 1
 fi
 

--- a/runAllExperiments.sh
+++ b/runAllExperiments.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+REPO="$1"
+MIN_COMMITS=50
+if [ "$#" -eq 2 ]; then
+    MIN_COMMITS="$2"
+fi
+FILE="allExperiments.cid"
+
+cat > $FILE <<- EOM
+new experimentSession
+loadGit ${REPO}
+compile
+pruneGit 1000 50 1000
+multiClassSingleModelTest
+multiClassTest
+twoClassTest
+quit
+EOM
+
+python3 coderID.py allExperiments.cid

--- a/runAllExperiments.sh
+++ b/runAllExperiments.sh
@@ -1,20 +1,32 @@
 #!/bin/bash
 REPO="$1"
+SESSION="experimentSession"
 MIN_COMMITS=50
-if [ "$#" -eq 2 ]; then
-    MIN_COMMITS="$2"
+
+if [ "$#" -gt 3 ] || [ "$#" -lt 1 ]; then
+    echo "Invalid number of  paramters. Usage: ./$0 repopath [ sessionName ] [ minCommits ]"
+    exit 1
 fi
+
+if [ "$#" -ge 2 ]; then
+    SESSION="$2"
+fi
+if [ "$#" -ge 3 ]; then
+    MIN_COMMITS="$3"
+fi
+
 FILE="allExperiments.cid"
 
 cat > $FILE <<- EOM
-new experimentSession
+new ${SESSION}
 loadGit ${REPO}
 compile
-pruneGit 1000 50 1000
+pruneGit 1000 ${MIN_COMMITS} 1000
 multiClassSingleModelTest
 multiClassTest
 twoClassTest
 quit
 EOM
 
+echo "Running session ${SESSION}"
 python3 coderID.py allExperiments.cid

--- a/runAllExperiments.sh
+++ b/runAllExperiments.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 REPO="$1"
 SESSION="experimentSession"
-MIN_COMMITS=50
+MIN_FUNCTIONS=50
 
+# Parse command line args
 if [ "$#" -gt 3 ] || [ "$#" -lt 1 ]; then
-    echo "Invalid number of paramters. Usage: ./$0 repopath [ sessionName ] [ minCommits ]"
+    echo "Invalid number of paramters. Usage: ./$0 repopath [ sessionName ] [ minFunctions ]"
     exit 1
 fi
 
@@ -12,21 +13,23 @@ if [ "$#" -ge 2 ]; then
     SESSION="$2"
 fi
 if [ "$#" -ge 3 ]; then
-    MIN_COMMITS="$3"
+    MIN_FUNCTIONS="$3"
 fi
 
+# Create script file
 FILE="allExperiments.cid"
 
 cat > $FILE <<- EOM
 new ${SESSION}
 loadGit ${REPO}
 compile
-pruneGit 1000 ${MIN_COMMITS} 1000
+pruneGit 1000 ${MIN_FUNCTIONS} 1000
 multiClassSingleModelTest
 multiClassTest
 twoClassTest
 quit
 EOM
 
+# Run experiments
 echo "Running session ${SESSION}"
 python3 coderID.py allExperiments.cid

--- a/runAllExperiments.sh
+++ b/runAllExperiments.sh
@@ -5,7 +5,7 @@ MIN_FUNCTIONS=50
 
 # Parse command line args
 if [ "$#" -gt 3 ] || [ "$#" -lt 1 ]; then
-    echo "Invalid number of paramters. Usage: ./$0 repopath [ sessionName ] [ minFunctions ]"
+    echo "Invalid number of parameters. Usage: ./$0 repopath [ sessionName ] [ minFunctions ]"
     exit 1
 fi
 


### PR DESCRIPTION
#### Main changes

Created a bash script for running all the experiments for a given repo.
Usage:
`./runAllExperiments pathToRepo [ sessionName ]  [ minCommitsPerAuthor ]`

The argument `sessionName` is optional and defaults to `experimentSession`
The argument `minCommitsPerAuthor` is also optional and defaults to 50. This was included to make testing easier for repos where authors have very few functions.

Example usage:
`./runAllExperiments gitRepo/caffe caffetest 50`

#### Other changes
- Fixed the bar graph script to use the passed in file name
- Added a print statement when an exception occurs running a cid script. This makes it easier to debug scripts.
- Changed the report filename for multiclass experiments with a single model to be different from the other multiclass test. 